### PR TITLE
Compatible with Keras 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,120 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+*.iws
+
+# C extensions
+*.so
+
+# Pycharm files
+../.idea
+**/../.idea
+**/.idea/
+.idea/
+.idea/*
+
+# documentation
+_build/
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+/conda_recipe/
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+*.ipynb
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# mac os
+.DS_Store

--- a/NGF/models.py
+++ b/NGF/models.py
@@ -2,7 +2,8 @@
 '''
 from __future__ import division, print_function, absolute_import
 
-from keras.regularizers import l1l2
+# from keras.regularizers import l1_l2  # keras 1.2
+from keras.regularizers import l1_l2  # keras 2.*
 from keras.layers import Input, merge, Dense, Dropout, BatchNormalization
 from keras import models
 
@@ -56,7 +57,7 @@ def build_graph_conv_model(max_atoms, max_degree, num_atom_features,
 	main_prediction = Dense(output_size, activation=final_activation, name='main_prediction')(net_output)
 
 	# Build and compile the model
-	model = models.Model(input=[atoms, bonds, edges], output=[main_prediction])
+	model = models.Model(inputs=[atoms, bonds, edges], outputs=[main_prediction])
 	model.compile(optimizer=optimizer, loss=loss)
 
 	return model
@@ -184,8 +185,8 @@ def build_graph_conv_net(data_input,
 			fp_atoms_in = ConvDropout(fp_dropout)(fp_atoms_in)
 
 		fp_out = NeuralGraphOutput(fp_size, activation=fp_activation, bias=fp_bias,
-								   W_regularizer=l1l2(fp_l1, fp_l2),
-								   b_regularizer=l1l2(fp_l1, fp_l2),
+								   W_regularizer=l1_l2(fp_l1, fp_l2),
+								   b_regularizer=l1_l2(fp_l1, fp_l2),
 								   **fp_kwargs)([fp_atoms_in, bonds, edges])
 		fingerprint_outputs.append(fp_out)
 
@@ -210,8 +211,8 @@ def build_graph_conv_net(data_input,
 		# 	the most powerfull (e.g. allows custom activation functions)
 		def inner_layer_fn():
 			return Dense(conv_size, activation=conv_activation, bias=conv_bias,
-						 W_regularizer=l1l2(conv_l1, conv_l2),
-						 b_regularizer=l1l2(conv_l1, conv_l2), **conv_kwargs)
+						 W_regularizer=l1_l2(conv_l1, conv_l2),
+						 b_regularizer=l1_l2(conv_l1, conv_l2), **conv_kwargs)
 		atoms_out = NeuralGraphHidden(inner_layer_fn)([atoms_in, bonds, edges])
 
 		if graphpool:
@@ -230,8 +231,8 @@ def build_graph_conv_net(data_input,
 				fp_atoms_in = ConvDropout(fp_dropout)(fp_atoms_in)
 
 			fp_out = NeuralGraphOutput(fp_size, activation=fp_activation, bias=fp_bias,
-									   W_regularizer=l1l2(fp_l1, fp_l2),
-									   b_regularizer=l1l2(fp_l1, fp_l2),
+									   W_regularizer=l1_l2(fp_l1, fp_l2),
+									   b_regularizer=l1_l2(fp_l1, fp_l2),
 									   **fp_kwargs)([fp_atoms_in, bonds, edges])
 
 			# Export
@@ -261,8 +262,8 @@ def build_graph_conv_net(data_input,
 			net_in = Dropout(net_dropout)(net_in)
 
 		net_out = Dense(layer_size, activation=net_activation, bias=net_bias,
-						W_regularizer=l1l2(net_l1, net_l2),
-						b_regularizer=l1l2(net_l1, net_l2), **net_kwargs)(net_in)
+						W_regularizer=l1_l2(net_l1, net_l2),
+						b_regularizer=l1_l2(net_l1, net_l2), **net_kwargs)(net_in)
 
 		# Export
 		net_outputs.append(net_out)


### PR DESCRIPTION
This version is compatible with both Keras 2 and Tensorflow backend. All the examples run as expected. The `filter_func_args` function inside utils still needs to adapt the Keras 2 style of arguments. However, this latter issue only causes a deprecation warning for the example #3.